### PR TITLE
replace prov:wasUsedBy by prov:used

### DIFF
--- a/examples/animal_antics.ttl
+++ b/examples/animal_antics.ttl
@@ -38,8 +38,7 @@
     dct:format <XMLFormat> ;
     premis:hasFixity <0912-0001Fixity> ;
     premis:hasSize "58465" ;
-    premis:hasCompositionLevel "0" ;
-    prov:wasUsedBy <0912-0001Event> .
+    premis:hasCompositionLevel "0" .
 
 <XMLFormat> a dct:FileFormat ;
     rdfs:label "Extensible Markup Language" ;
@@ -54,7 +53,8 @@
     prov:startedAtTime "2017-11-14T13:23:30Z" ;
     prov:endedAtTime "2017-11-14T13:26:11Z" ;
     evRelAgRole:aut <NRI> ;
-    evRelAgRole:imp <JaneDoe> .
+    evRelAgRole:imp <JaneDoe> ;
+    prov:used <http://nri.library.ca/0912-0001.xml> .
 
 <JaneDoe> a prov:Person ;
     foaf:name "Doe, Jane" ;


### PR DESCRIPTION
prov:wasUsedBy isn't an official property in the PROV Ontology. It is actually just a recommended inverse property. I suggest the example uses the canonical prov:used from the Activity to the Entity as opposed to prov:wasUsedBy from Entity to Activity.